### PR TITLE
SPL based on exam flights

### DIFF
--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -274,6 +274,7 @@ export function getStatistics(data: Flight[]): Stats {
 	if (airplanes.includes('LS-8a')) hasLicense = true;
 	if (airplanes.includes('LS-4b')) hasLicense = true;
 	if (airplanes.includes('ASG-29')) hasLicense = true;
+	if (examFlights.length > 0) hasLicense = true;
 
 	return {
 		pilot,


### PR DESCRIPTION
Any reason why the SPL is not based on exam flights instead of flown types?